### PR TITLE
Repo standardization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+yarn.lock linguist-generated=false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+*                                    @MetaMask/devs

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "standard": "^14.3.3",
     "tape": "^5.0.0"
   },
+  "engines": {
+    "node": ">=14.15.4"
+  },
   "scripts": {
     "setup": "yarn install && patch-package && allow-scripts",
     "test": "concurrently --kill-others --success=first 'npm:test:ganache' 'npm:test:server' 'npm:test:runner'",


### PR DESCRIPTION
Related: https://github.com/MetaMask/MetaMask-planning/issues/32
- Adding `engines` entry for minimum Node version of 14.15.4
- Adding basic .editorconfig file
- Adding basic .gitattributes file
- Adding Github CODEOWNERS file