### PR TITLE
Proposed changes for multi-testnet faucet option

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -87,6 +87,11 @@ function startServer () {
   async function handleRequest (req, res) {
     try {
       // parse address
+      // can parse for network here.
+      // can either be json object or
+      // inserted in a combined rawdata string with address, and then parsed out here
+      // depending on what the network is, make sure ethQuery engine knows when 
+      // testing balance and sending transaction
       let targetAddress = req.body
       if (!targetAddress || typeof targetAddress !== 'string') {
         return didError(res, new Error(`Address parse failure - request body empty`))

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -36,6 +36,8 @@ console.log('Acting as faucet for address:', config.address)
 //
 
 // ProviderEngine based caching layer, with fallback to geth
+// 
+// need to be able to dynamically change rpcOrigin based on network requesting funds
 const engine = rpcWrapperEngine({
   rpcUrl: config.rpcOrigin,
   addressHex: config.address,
@@ -110,6 +112,8 @@ function startServer () {
       const alignedIpAddress = ipAddress.padStart(15, ' ')
       const requestorMessage = `${flag} ${alignedIpAddress} requesting for ${targetAddress}`
       // check for greediness
+      //
+      // need to change network here:
       const balance = await ethQuery.getBalance(targetAddress, 'pending')
       const balanceTooFull = balance.gt(MAX_BALANCE)
       if (balanceTooFull) {
@@ -117,6 +121,7 @@ function startServer () {
         return didError(res, new Error('User is greedy - already has too much ether'))
       }
       // send value
+      // need ot change network here as well:
       const txHash = await ethQuery.sendTransaction({
         to: targetAddress,
         from: config.address,

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -57,6 +57,27 @@ function getNetwork () {
     if (res.error) return console.res.error(res.error)
     var network = res.result
     state.network = network
+
+    // set networkName for use in etherscan URL
+    switch(network) {
+      case '3': 
+        state.networkName = 'ropsten';
+        break
+      case '42':
+        state.networkName = 'kovan';
+        break  
+      case '4':
+        state.networkName = 'rinkeby';
+        break
+      case '5':
+        state.networkName = 'goerli';
+        break  
+      // not sure about the best way to handle this, but
+      // need to have something if they're on non-public testnet  
+      default:
+        state.networkName = 'unknown';
+        break  
+    }
     renderApp()
   })
 }
@@ -209,7 +230,7 @@ function renderApp () {
           }
         }, (
           state.transactions.map((txHash) => {
-            return link(`https://ropsten.etherscan.io/tx/${txHash}`, txHash)
+            return link(`https://${state.networkName}.etherscan.io/tx/${txHash}`, txHash)
           })
         ))
       ])
@@ -232,16 +253,18 @@ async function getEther () {
   if (!account) return
 
   var uri = `${window.location.href}v0/request`
-  var data = account
+  var data = {
+    'account' : account,
+    'network' : state.network,
+  }
 
   let res, body, err
-  
   try {
     res = await fetch(uri, {
       method: 'POST',
       body: data,
       headers: {
-        'Content-Type': 'application/rawdata'
+        'Content-Type': 'application/json'
       }
     })
     body = await res.text()


### PR DESCRIPTION
Hey there, two main changes:

- The first is on the webapp side, where it's mainly about providing a valid etherscan URL that's not just ropsten
- The second is _proposed_ changes on server file, showing where I think the indicated network will be.

I'm not familiar enough with the codebase or ethQuery to make the best decision about this, but will message you on slack as well.

The other thing I'm stuck on is the best way to encode which network the user wants when sending the `POST` request -- it could either be stuck onto the front of the rawdata string that's parsed, or the webapp can format the `req` into a JSON. but I think parsing a JSON on the server side might be a little too weird, but you would know best.